### PR TITLE
Fix package.json information

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "suppose",
   "version": "0.4.0",
   "description": "Automate command line programs. Like UNIX expect.",
-  "homepage": [
-    "https://github.com/jprichardson/node-fnoc"
-  ],
+  "homepage": "https://github.com/jprichardson/node-suppose",
   "repository": {
     "type": "git",
     "url": "https://github.com/jprichardson/node-suppose"
@@ -17,12 +15,7 @@
     "unix"
   ],
   "author": "JP Richardson <jprichardson@gmail.com>",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/jprichardson/node-suppose/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "dependencies": {
     "force-array": "^3.1.0",
     "string": "~3.3.1"


### PR DESCRIPTION
While I was fixing the documentation for #15, I noticed a few errors in `package.json`.  This PR fixes the following issues:

* It looks like `homepage` was copied over from node-fnoc, fix it.
* Fix `license` to use the SPDX license ID, as documented in `package.json(5)`.  This fixes the `npm WARN suppose@0.4.0 No license field.` warning printed by npm when running `npm install`.

Thanks for considering,
Kevin