### PR TITLE
Don't cause uncaughtException on unexpected input

### DIFF
--- a/lib/suppose-stream.js
+++ b/lib/suppose-stream.js
@@ -27,8 +27,8 @@ function SupposeStream(debug) {
     {
       var expect = this.expects.shift()
 
-      condition = expect.condition
-      responses = expect.responses
+      condition = expect && expect.condition
+      responses = expect && expect.responses
 
       needNew = false
     }

--- a/test/suppose-stream.test.js
+++ b/test/suppose-stream.test.js
@@ -22,12 +22,19 @@ describe('stream', function()
       .when('Hi').respond('Bye')
     .pipe(output)
 
-    input.push('Hi')
     output.once('data', function(chunk, encoding, next)
     {
       assert.strictEqual(chunk.toString(), 'Bye')
 
-      done()
+      output.once('data', function(chunk, encoding, next)
+      {
+        throw new Error('Unexpected output: ' + chunk);
+      })
     })
+    output.once('error', done)
+    output.once('end', done)
+
+    input.push('Hi')
+    input.push('Unexpected')
   })
 })


### PR DESCRIPTION
A regression in 0.4.0 meant that additional input, after all expectations had been met, caused an `uncaughtException` due to `expect` being `undefined` at `lib/suppose-stream.js:30`.  Fix the error by behaving as 0.3.1 did and silently ignoring further input.

Extend the test to cover this case by adding unexpected input.

Further extend the test case to check for unexpected output or errors from the output stream and to ensure `'end'` is emitted on this stream.

Thanks for considering,
Kevin