### PR TITLE
End SupposeStream output when no expectations

### DIFF
--- a/lib/suppose-process.js
+++ b/lib/suppose-process.js
@@ -69,6 +69,10 @@ function SupposeProcess(command, args, options)
       debug.write(S('-').times(cmdString.length) + '\n')
     }
 
+    // Empty write signals SupposeStream that input has started and .when()
+    // will not be called again so it can end output early where possible.
+    supposeStream.write('')
+
     exe.stdout.pipe(supposeStream).pipe(exe.stdin)
 
     exe.stderr.on('data', function(data)

--- a/lib/suppose-stream.js
+++ b/lib/suppose-stream.js
@@ -14,6 +14,7 @@ function SupposeStream(debug) {
 
   var readBuffer = ''
   var needNew = true
+  var sentEof = false
 
   var condition
   var responses
@@ -29,6 +30,13 @@ function SupposeStream(debug) {
 
       condition = expect && expect.condition
       responses = expect && expect.responses
+
+      if(!expect && !sentEof)
+      {
+        // this.expects was always empty
+        this.push(null)
+        sentEof = true
+      }
 
       needNew = false
     }
@@ -59,9 +67,13 @@ function SupposeStream(debug) {
 
           if(debug) debug.write(response, 'utf8')
         }
-
-        if(!this.expects.length) this.push(null)
       }, this)
+
+      if(!this.expects.length)
+      {
+        this.push(null)
+        sentEof = true
+      }
     }
 
     callback()

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "unix"
   ],
   "author": "JP Richardson <jprichardson@gmail.com>",
+  "contributors": [
+    "Kevin Locke <kevin@kevinlocke.name>"
+  ],
   "license": "MIT",
   "dependencies": {
     "force-array": "^3.1.0",

--- a/test/suppose-process.test.js
+++ b/test/suppose-process.test.js
@@ -145,4 +145,15 @@ describe('process', function()
       done()
     })
   })
+
+  it('should end if no expectations and no output', function(done)
+  {
+    suppose('cat')
+    .end(function(code)
+    {
+      assert.strictEqual(code, 0)
+
+      done()
+    })
+  })
 })

--- a/test/suppose-stream.test.js
+++ b/test/suppose-stream.test.js
@@ -37,4 +37,19 @@ describe('stream', function()
     input.push('Hi')
     input.push('Unexpected')
   })
+
+  it('should end if no expectations', function(done)
+  {
+    var suppose = new SupposeStream()
+
+    suppose.once('data', function(chunk, encoding, next)
+    {
+      throw new Error('Unexpected output: ' + chunk);
+    })
+    suppose.once('error', done)
+    suppose.once('end', done)
+
+    suppose.write('Hi')
+    // stream should end without end of input
+  })
 })


### PR DESCRIPTION
This PR fixes the issue mentioned in #17 that if there are no expectations, the output stream should be ended immediately (as it is after the last expectation is met).  It checks for this condition when the `expect` array is empty after being dequeued and updates the test suite to test for this condition.

It also fixes a bug where the output stream would not be ended if the last expectation didn't have a response (or `null` pushed multiple times for multiple responses).

Thanks for considering,
Kevin