### PR TITLE
fix(windows): fix spawn ENOENT on Windows environments

### DIFF
--- a/lib/suppose-process.js
+++ b/lib/suppose-process.js
@@ -72,6 +72,7 @@ function SupposeProcess(command, args, options)
 
   this.end = function(callback)
   {
+    options = process.platform === 'win32' ? Object.assign({}, options, { shell: true }) : options
     exe = spawn(command, args, options)
 
     if(debug)


### PR DESCRIPTION
Hi! Running on Windows environments results in `spawn ENOENT` error and this oneliner fixes it. 